### PR TITLE
Fix 1.8 support

### DIFF
--- a/src/main/java/net/devtm/tmtokens/listener/BasicListener.java
+++ b/src/main/java/net/devtm/tmtokens/listener/BasicListener.java
@@ -44,7 +44,8 @@ public class BasicListener implements Listener {
                         .replace("%pl_time%", (cooldown.get(event.getPlayer().getUniqueId()) - System.currentTimeMillis() + newTime+1 )/1000 + "").toStringColor());
                 return;
             }
-        if(Objects.isNull(event.getPlayer().getInventory().getItemInMainHand().getItemMeta())) return;
+        
+        if(Objects.isNull(event.getPlayer().getInventory().getItemInHand().getItemMeta())) return;
 
         NamespacedKey key = new NamespacedKey(TMTokens.PLUGIN.getPlugin(), "coin");
         if(!event.getAction().equals(Action.RIGHT_CLICK_BLOCK) || !event.getAction().equals(Action.RIGHT_CLICK_AIR))


### PR DESCRIPTION
A person using this plugin had errors in the console when triggering the PlayerInteractEvent event, I noticed that in 1.10 they added the getItemInMainHand() and it is used here. So basically you broke the 1.8 support, I added back getItemInHand() which does support the version and eliminates the error completely.

Also the isNull on the getInventory() is redundant, because already is overrided by a @NotNull.